### PR TITLE
Add reference to repository and MSDN documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The returned object `certs` is a object like this:
 }
 ```
 
+See also MSDN documentation on:
+
+* [StoreName](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.storename(v=vs.110).aspx)
+* [StoreLocation](https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.storelocation(v=vs.110).aspx)
+
 ## License
 
 MIT 2015 - José F. Romaniello

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "mocha"
   },
   "author": "Jose F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jfromaniello/node-windows-certs.git"
+  },
   "license": "MIT",
   "devDependencies": {
     "mocha": "2.2.1"


### PR DESCRIPTION
Adding reference to the repository in package.json creates a convenient link from the [NPM page](https://www.npmjs.com/package/windows-certs) to the [repository](https://github.com/jfromaniello/node-windows-certs).

Also, adding links to the MSDN documentation for StoreName and StoreLocation to help developers find valid values.  These enums could also be exposed at some point.
